### PR TITLE
feat: swapper v5

### DIFF
--- a/contracts/SwapperV4.sol
+++ b/contracts/SwapperV4.sol
@@ -3,8 +3,8 @@ pragma solidity ^0.8.18;
 
 import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
-import {ICurve} from "./interfaces/curve/ICurve.sol";
-import {ICurveInt128} from "./interfaces/curve/ICurveInt128.sol";
+import {ICurve} from "contracts/interfaces/curve/ICurve.sol";
+import {ICurveInt128} from "contracts/interfaces/curve/ICurveInt128.sol";
 
 interface IZap {
     function zap(
@@ -168,7 +168,7 @@ contract SwapperV4 {
     function priceOracle() public view returns (uint) {
         uint oraclePricePool1 = pool1.price_oracle(1); // 1 = CRV index
         uint oraclePricePool2 = pool2.price_oracle();
-        return (PRECISION * oraclePricePool2) / oraclePricePool1;
+        return 1e54 / (oraclePricePool1 * oraclePricePool2);
     }
 
     function sweep(address _token) external onlyOwnerOrManagement {

--- a/contracts/SwapperV5.sol
+++ b/contracts/SwapperV5.sol
@@ -36,6 +36,8 @@ interface IVault is IERC20 {
     function strategies(address) external returns (StrategyParams memory);
 
     function asset() external returns (address);
+
+    function token() external returns (address);
 }
 
 contract SwapperV5 {
@@ -59,6 +61,7 @@ contract SwapperV5 {
         IVault(0x27B5739e22ad9033bcBf192059122d163b60349D);
     address public management;
     mapping(address => bool) public allowedSwapper;
+    mapping(address => bool) public operator;
 
     modifier isAllowedSwapper() {
         require(
@@ -82,9 +85,20 @@ contract SwapperV5 {
         _;
     }
 
+    modifier onlyOperator() {
+        require(
+            msg.sender == owner ||
+                msg.sender == management ||
+                operator[msg.sender],
+            "!operator"
+        );
+        _;
+    }
+
     event OTC(uint price, uint sellTokenAmount, uint buyTokenAmount);
     event SetVault(address indexed vault);
     event SetAllowedSwapper(address indexed caller, bool indexed isAllowed);
+    event SetOperator(address indexed caller, bool indexed isAllowed);
     event SetManagement(address indexed management);
     event OTCEnabled(bool indexed enabled);
 
@@ -102,6 +116,8 @@ contract SwapperV5 {
         pool1 = _pool1;
         pool2 = _pool2;
         tokenOutPool1 = _tokenOutPool1;
+
+        require(address(_tokenOut) == approvedVault.token(), "!token");
 
         uint idxFound;
         address token;
@@ -159,6 +175,7 @@ contract SwapperV5 {
             uint256 vaultBalance = approvedVault.balanceOf(address(this));
             if (vaultBalance > amountToBuy) {
                 // this will actually withdraw ~2x the yCRV since PPS is around 2
+                // note that since this is a V2 vault, input amount is shares, not underlying
                 approvedVault.withdraw(amountToBuy, address(this));
             } else {
                 if (vaultBalance > 0) {
@@ -190,7 +207,7 @@ contract SwapperV5 {
         if (amount > 0) ERC20(_token).safeTransfer(owner, amount);
     }
 
-    function enableOtc(bool _enabled) external onlyOwnerOrManagement {
+    function enableOtc(bool _enabled) external onlyOperator {
         otcEnabled = _enabled;
         emit OTCEnabled(_enabled);
     }
@@ -211,6 +228,15 @@ contract SwapperV5 {
     ) external onlyOwnerOrManagement {
         allowedSwapper[_caller] = _isAllowed;
         emit SetAllowedSwapper(_caller, _isAllowed);
+    }
+
+    // Permit a caller to enable and disable OTC
+    function setOperator(
+        address _caller,
+        bool _isAllowed
+    ) external onlyOwnerOrManagement {
+        operator[_caller] = _isAllowed;
+        emit SetOperator(_caller, _isAllowed);
     }
 
     function setManagement(address _management) external onlyOwner {

--- a/contracts/SwapperV5.sol
+++ b/contracts/SwapperV5.sol
@@ -1,0 +1,220 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.18;
+
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {SafeERC20, IERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {ICurve} from "contracts/interfaces/curve/ICurve.sol";
+import {ICurveInt128} from "contracts/interfaces/curve/ICurveInt128.sol";
+
+interface IZap {
+    function zap(
+        address _inputToken,
+        address _outputToken,
+        uint256 _amountIn,
+        uint256 _minOut,
+        address _recipient
+    ) external returns (uint256);
+}
+
+interface IVault is IERC20 {
+    struct StrategyParams {
+        uint256 performanceFee;
+        uint256 activation;
+        uint256 debtRatio;
+        uint256 minDebtPerHarvest;
+        uint256 maxDebtPerHarvest;
+        uint256 lastReport;
+        uint256 totalDebt;
+        uint256 totalGain;
+        uint256 totalLoss;
+    }
+
+    function deposit(uint amount, address recipient) external returns (uint);
+
+    function withdraw(uint shares, address recipient) external returns (uint);
+
+    function strategies(address) external returns (StrategyParams memory);
+
+    function asset() external returns (address);
+}
+
+contract SwapperV5 {
+    using SafeERC20 for ERC20;
+
+    uint public constant PRECISION = 1e18;
+    ERC20 public immutable tokenIn;
+    ERC20 public immutable tokenOut;
+    ERC20 public immutable tokenOutPool1;
+    ICurve public immutable pool1;
+    ICurveInt128 public immutable pool2;
+    uint public immutable pool1InTokenIdx;
+    uint public immutable pool1OutTokenIdx;
+    bool public otcEnabled;
+    address public constant owner = 0xFEB4acf3df3cDEA7399794D0869ef76A6EfAff52;
+    address public constant treasury =
+        0x93A62dA5a14C80f265DAbC077fCEE437B1a0Efde;
+    IZap public constant zap = IZap(0x78ada385b15D89a9B845D2Cac0698663F0c69e3C);
+    IVault public vault = IVault(0xBF319dDC2Edc1Eb6FDf9910E39b37Be221C8805F);
+    IVault public constant approvedVault =
+        IVault(0x27B5739e22ad9033bcBf192059122d163b60349D);
+    address public management;
+    mapping(address => bool) public allowedSwapper;
+
+    modifier isAllowedSwapper() {
+        require(
+            approvedVault.strategies(msg.sender).activation > 0 ||
+                allowedSwapper[msg.sender],
+            "!AllowedSwapper"
+        );
+        _;
+    }
+
+    modifier onlyOwner() {
+        require(msg.sender == owner, "!owner");
+        _;
+    }
+
+    modifier onlyOwnerOrManagement() {
+        require(
+            msg.sender == owner || msg.sender == management,
+            "!ownerOrManagement"
+        );
+        _;
+    }
+
+    event OTC(uint price, uint sellTokenAmount, uint buyTokenAmount);
+    event SetVault(address indexed vault);
+    event SetAllowedSwapper(address indexed caller, bool indexed isAllowed);
+    event SetManagement(address indexed management);
+    event OTCEnabled(bool indexed enabled);
+
+    constructor(
+        address _management,
+        ERC20 _tokenIn,
+        ERC20 _tokenOut,
+        ICurve _pool1,
+        ERC20 _tokenOutPool1,
+        ICurveInt128 _pool2
+    ) {
+        tokenIn = _tokenIn;
+        tokenOut = _tokenOut;
+        management = _management;
+        pool1 = _pool1;
+        pool2 = _pool2;
+        tokenOutPool1 = _tokenOutPool1;
+
+        uint idxFound;
+        address token;
+
+        for (uint i; i < 3; ++i) {
+            token = _pool1.coins(i);
+            if (token == address(_tokenIn)) {
+                pool1InTokenIdx = i;
+                idxFound++;
+                if (idxFound == 2) break;
+            }
+            if (token == address(_tokenOutPool1)) {
+                pool1OutTokenIdx = i;
+                idxFound++;
+                if (idxFound == 2) break;
+            }
+        }
+
+        tokenIn.approve(address(_pool1), type(uint).max);
+        tokenIn.approve(address(vault), type(uint).max);
+        tokenOutPool1.approve(address(zap), type(uint).max);
+    }
+
+    function swap(uint _amount) external returns (uint profit) {
+        tokenIn.safeTransferFrom(msg.sender, address(this), _amount);
+        if (otcEnabled) (profit, _amount) = _sellOtc(_amount);
+        if (_amount < PRECISION) return profit;
+        uint out = pool1.exchange_underlying(
+            pool1InTokenIdx,
+            pool1OutTokenIdx,
+            _amount,
+            0
+        );
+        return
+            profit += zap.zap(
+                address(tokenOutPool1),
+                address(tokenOut),
+                out,
+                0,
+                msg.sender
+            );
+    }
+
+    // Returns amount of profit and amount of sell tokens remaining to be sold.
+    function _sellOtc(
+        uint _sellTokenAmount
+    ) internal isAllowedSwapper returns (uint, uint) {
+        ERC20 buyToken = tokenOut;
+        uint price = priceOracle();
+        uint amountToSell = _sellTokenAmount;
+        uint amountToBuy = (amountToSell * price) / PRECISION;
+        uint buyTokenBalance = buyToken.balanceOf(address(this));
+        if (amountToBuy > buyTokenBalance) {
+            // check for vault tokens to withdraw from
+            uint256 vaultBalance = approvedVault.balanceOf(address(this));
+            if (vaultBalance > amountToBuy) {
+                // this will actually withdraw ~2x the yCRV since PPS is around 2
+                approvedVault.withdraw(amountToBuy, address(this));
+            } else {
+                if (vaultBalance > 0) {
+                    approvedVault.withdraw(vaultBalance, address(this));
+                    buyTokenBalance = buyToken.balanceOf(address(this));
+                }
+                if (amountToBuy > buyTokenBalance) {
+                    amountToBuy = buyTokenBalance;
+                    amountToSell = (PRECISION * buyTokenBalance) / price;
+                }
+            }
+        }
+        buyToken.safeTransfer(msg.sender, amountToBuy);
+        vault.deposit(amountToSell, treasury);
+        emit OTC(price, amountToSell, amountToBuy);
+        return (amountToBuy, _sellTokenAmount - amountToSell);
+    }
+
+    // This function is not generic and is strictly for pricing crvUSD to yCRV
+    // Returns the price of crvUSD to yCRV
+    function priceOracle() public view returns (uint) {
+        uint oraclePricePool1 = pool1.price_oracle(1); // 1 = CRV index
+        uint oraclePricePool2 = pool2.price_oracle();
+        return 1e54 / (oraclePricePool1 * oraclePricePool2);
+    }
+
+    function sweep(address _token) external onlyOwnerOrManagement {
+        uint amount = ERC20(_token).balanceOf(address(this));
+        if (amount > 0) ERC20(_token).safeTransfer(owner, amount);
+    }
+
+    function enableOtc(bool _enabled) external onlyOwnerOrManagement {
+        otcEnabled = _enabled;
+        emit OTCEnabled(_enabled);
+    }
+
+    // Owner only function to switch the vault used to wrap the purchased asset before transferring to treasury
+    function setVault(IVault _vault) external onlyOwner {
+        require(_vault.asset() == address(tokenIn), "wrong asset");
+        tokenIn.approve(address(vault), 0);
+        tokenIn.approve(address(_vault), type(uint256).max);
+        vault = _vault;
+        emit SetVault(address(_vault));
+    }
+
+    // Permit a caller to OTC against funds in this contract
+    function setAllowedSwapper(
+        address _caller,
+        bool _isAllowed
+    ) external onlyOwnerOrManagement {
+        allowedSwapper[_caller] = _isAllowed;
+        emit SetAllowedSwapper(_caller, _isAllowed);
+    }
+
+    function setManagement(address _management) external onlyOwner {
+        management = _management;
+        emit SetManagement(_management);
+    }
+}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -151,6 +151,19 @@ def swapper_v4(gov, token, SwapperV4, management):
 
 
 @pytest.fixture
+def swapper_v5(gov, token, SwapperV5, management):
+    token_in = "0xf939E0A03FB07F59A73314E73794Be0E57ac1b4E"  # crvUSD
+    token_out = token
+    token_out_pool1 = "0xD533a949740bb3306d119CC777fa900bA034cd52"
+    pool1 = "0x4eBdF703948ddCEA3B11f675B4D1Fba9d2414A14"
+    pool2 = "0x99f5acc8ec2da2bc0771c32814eff52b712de1e5"
+    swapper = gov.deploy(
+        SwapperV5, management, token_in, token_out, pool1, token_out_pool1, pool2
+    )
+    yield swapper
+
+
+@pytest.fixture
 def swapper_v2(gov, reward_token, token, ybs, SwapperV2):
     token_in = "0xf939E0A03FB07F59A73314E73794Be0E57ac1b4E"  # crvUSD
     token_out = token

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,12 +45,38 @@ def token():
 
 
 @pytest.fixture
-def amount(accounts, token, user):
+def fund_ycrv(accounts, token):
+    holders = [
+        accounts.at("0x1Effd55A8646F7Dc67C7578c20Ce575CefEB1120", force=True),
+        accounts.at("0xC5240FD754F4C52A3Cb71AB8625FB8E810E6fBB7", force=True),
+        accounts.at("0xEfb8B98A4BBd793317a863f1Ec9B92641aB1CBbb", force=True),
+    ]
+
+    def fund(recipient, amount=None):
+        if amount is None:
+            for holder in holders:
+                balance = token.balanceOf(holder)
+                if balance > 0:
+                    token.transfer(recipient, balance, {"from": holder})
+            return
+
+        remaining = amount
+        for holder in holders:
+            to_transfer = min(token.balanceOf(holder), remaining)
+            if to_transfer > 0:
+                token.transfer(recipient, to_transfer, {"from": holder})
+                remaining -= to_transfer
+            if remaining == 0:
+                return
+        raise ValueError(f"Unable to source {amount / 1e18:,.2f} yCRV")
+
+    yield fund
+
+
+@pytest.fixture
+def amount(token, user, fund_ycrv):
     amount = 10_000 * 10 ** token.decimals()
-    # In order to get some funds for the token you are about to use,
-    # it impersonate an exchange address to use it's funds.
-    reserve = accounts.at("0x99f5aCc8EC2Da2BC0771c32814EFF52b712de1E5", force=True)
-    token.transfer(user, amount, {"from": reserve})
+    fund_ycrv(user, amount)
     yield amount
 
 
@@ -192,10 +218,10 @@ def strategy(
     old_strategy,
     token,
     registry,
-    swapper_v3,
+    swapper_v5,
 ):
     # deploy!
-    strategy = strategist.deploy(Strategy, vault, ybs, reward_distributor, swapper_v3)
+    strategy = strategist.deploy(Strategy, vault, ybs, reward_distributor, swapper_v5)
     strategy.setKeeper(keeper)
 
     # check and print starting boost of strategy
@@ -268,7 +294,7 @@ def crvusd_dummy_vault(reward_token, gov):
 def crvusd_whale(accounts, token, user, reward_token):
     # In order to get some funds for the token you are about to use,
     # it impersonate an exchange address to use it's funds.
-    amount = 100_000e18
+    amount = 100_000 * 10**18
     crvusd = Contract(reward_token.asset())
     reserve = accounts.at("0xA920De414eA4Ab66b97dA1bFE9e6EcA7d4219635", force=True)
     crvusd.transfer(user, amount, {"from": reserve})

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -6,24 +6,32 @@ WEEK = 60 * 60 * 24 * 7
 
 
 def test_swapper(
-    swapper_v3, vault, deposit_rewards, chain, strategy, gov, crvusd_dummy_vault
+    swapper_v5,
+    vault,
+    deposit_rewards,
+    chain,
+    strategy,
+    gov,
+    management,
+    crvusd_dummy_vault,
+    fund_ycrv,
 ):
-    price = 1 / (swapper_v3.priceOracle() / 1e18)  # yCRV price as crvUSD
+    price = 1 / (swapper_v5.priceOracle() / 1e18)  # yCRV price as crvUSD
     assert price > 0.10 and price < 1.0
+    assert strategy.swapper() == swapper_v5
     tx = strategy.harvest()
-    whale = accounts.at("0x71E47a4429d35827e0312AA13162197C23287546", force=True)
-    ycrv = Contract(vault.token())
     chain.sleep(3 * WEEK)
     chain.mine()
 
-    v = swapper_v3.vault()
-    swapper_v3.setVault(crvusd_dummy_vault, {"from": gov})
-    swapper_v3.setVault(v, {"from": gov})
+    v = swapper_v5.vault()
+    swapper_v5.setVault(crvusd_dummy_vault, {"from": gov})
+    swapper_v5.setVault(v, {"from": gov})
+    swapper_v5.enableOtc(True, {"from": management})
 
-    amounts = [10e18, 100_000e18, 0]
+    amounts = [10 * 10**18, 100_000 * 10**18, 0]
 
     for i in range(3):
-        ycrv.transfer(swapper_v3, amounts[i], {"from": whale})
+        fund_ycrv(swapper_v5, amounts[i])
 
         deposit_rewards()
 
@@ -35,7 +43,7 @@ def test_swapper(
         event = tx.events["OTC"]
         print("Sell amount", event["sellTokenAmount"] / 1e18)
         print("Buy amount", event["buyTokenAmount"] / 1e18)
-        bal = Contract(swapper_v3.tokenOut()).balanceOf(swapper_v3) / 1e18
+        bal = Contract(swapper_v5.tokenOut()).balanceOf(swapper_v5) / 1e18
         print(f"Remaining OTC balance {bal}\n")
 
 
@@ -53,6 +61,7 @@ def test_operation(
     amount,
     RELATIVE_APPROX,
     deposit_rewards,
+    fund_ycrv,
 ):
     # do a harvest to get all of our loose vault funds into the strategy (assuming no more profitable harvests left)
     assert vault.strategies(strategy)["debtRatio"] == 10_000
@@ -111,6 +120,7 @@ def test_operation(
 
     # put it back up to 100%
     vault.updateStrategyDebtRatio(strategy, 10_000, {"from": gov})
+    chain.sleep(1)
     tx = strategy.harvest()
     try:
         minted = tx.events["Mint"]["value"]
@@ -126,14 +136,16 @@ def test_operation(
         print("🤑 Just swapped", swapped / 1e18, "CRV for", received / 1e18, "yCRV\n")
 
     # have a whale swap in a 500k yCRV
-    whale = accounts.at(
-        "0x71E47a4429d35827e0312AA13162197C23287546", force=True
-    )  # threshold multisig
+    whale = accounts.at("0x71E47a4429d35827e0312AA13162197C23287546", force=True)
     pool = Contract("0x99f5aCc8EC2Da2BC0771c32814EFF52b712de1E5")
+    swap_amount = 500_000 * 10 ** token.decimals()
+    fund_ycrv(whale)
+    assert token.balanceOf(whale) >= swap_amount
     token.approve(pool, 2**256 - 1, {"from": whale})
-    pool.exchange(1, 0, 500_000e18, 0, {"from": whale})
+    pool.exchange(1, 0, swap_amount, 0, {"from": whale})
 
     # now we should swap instead of minting
+    chain.sleep(1)
     tx = strategy.harvest()
     try:
         minted = tx.events["Mint"]["value"]

--- a/tests/test_swapper.py
+++ b/tests/test_swapper.py
@@ -24,7 +24,7 @@ def test_swapper(
     tx = strategy.harvest({"from": gov})
     strategy.upgradeSwapper(swapper, {"from": gov})
     assert swapper.management() == management
-    whale = accounts.at("0x71E47a4429d35827e0312AA13162197C23287546", force=True)
+    whale = accounts.at("0x2DbcBdB6ED8DF05dDc859bd9e06A53E93e1C9561", force=True)
     ycrv = Contract(vault.token())
     chain.sleep(3 * WEEK)
     chain.mine()
@@ -35,6 +35,15 @@ def test_swapper(
 
     amounts = [10e18, 1_000e18, 100_000e18, 0]
     swapper.enableOtc(True, {"from": management})
+
+    # test our operator role
+    with brownie.reverts("!operator"):
+        swapper.enableOtc(False, {"from": whale})
+    swapper.setOperator(whale, True, {"from": management})
+    swapper.enableOtc(False, {"from": whale})
+    assert not swapper.otcEnabled()
+    swapper.enableOtc(True, {"from": whale})
+    assert swapper.otcEnabled()
 
     status = swapper.otcEnabled()
 

--- a/tests/test_swapper.py
+++ b/tests/test_swapper.py
@@ -6,7 +6,7 @@ WEEK = 60 * 60 * 24 * 7
 
 
 def test_swapper(
-    swapper_v4,
+    swapper_v5,
     vault,
     deposit_rewards,
     chain,
@@ -15,10 +15,10 @@ def test_swapper(
     management,
     crvusd_dummy_vault,
 ):
-    swapper = swapper_v4
+    swapper = swapper_v5
     strategy = old_strategy
     old_swapper = Contract(strategy.swapper())
-    price = (swapper.priceOracle() / 1e18)  # yCRV price as crvUSD
+    price = 1e18 / swapper.priceOracle()  # yCRV price as crvUSD
     print("\n👀 Price:", price, "\n")
     assert price > 0.10 and price < 1.0
     tx = strategy.harvest({"from": gov})
@@ -55,11 +55,80 @@ def test_swapper(
             event = tx.events["OTC"]
             print("Sell amount", event["sellTokenAmount"] / 1e18)
             print("Buy amount", event["buyTokenAmount"] / 1e18)
-            print("Effective price:", event["sellTokenAmount"] / event["buyTokenAmount"])
+            print(
+                "Effective price:", event["sellTokenAmount"] / event["buyTokenAmount"]
+            )
             bal = Contract(swapper.tokenOut()).balanceOf(swapper) / 1e18
             print(f"Remaining OTC balance {bal}\n")
         else:
             assert "OTC" not in tx.events
+
+
+def test_swapper_withdraw(
+    swapper_v5,
+    vault,
+    deposit_rewards,
+    chain,
+    gov,
+    old_strategy,
+    management,
+    crvusd_dummy_vault,
+):
+    swapper = swapper_v5
+    strategy = old_strategy
+    old_swapper = Contract(strategy.swapper())
+    price = 1e18 / swapper.priceOracle()  # yCRV price as crvUSD
+    print("\n👀 Price:", price, "\n")
+    assert price > 0.10 and price < 1.0
+    tx = strategy.harvest({"from": gov})
+    strategy.upgradeSwapper(swapper, {"from": gov})
+    assert swapper.management() == management
+    whale = accounts.at(
+        "0xEfb8B98A4BBd793317a863f1Ec9B92641aB1CBbb", force=True
+    )  # st-ycrv whale
+    ycrv = Contract(vault.token())
+    chain.sleep(3 * WEEK)
+    chain.mine()
+
+    v = swapper.vault()
+    swapper.setVault(crvusd_dummy_vault, {"from": gov})
+    swapper.setVault(v, {"from": gov})
+
+    amounts = [10e18, 1_000e18, 100_000e18, 0]
+    swapper.enableOtc(True, {"from": management})
+
+    status = swapper.otcEnabled()
+
+    for i in range(len(amounts)):
+        vault.transfer(swapper, amounts[i], {"from": whale})
+
+        deposit_rewards()
+
+        chain.sleep(WEEK)
+        chain.mine()
+
+        status = swapper.otcEnabled()
+
+        tx = strategy.harvest({"from": gov})
+
+        # first 2 shouldn't do any OTC
+        vault_balance = vault.balanceOf(swapper)
+
+        if status:
+            assert "OTC" in tx.events
+            event = tx.events["OTC"]
+            print("Sell amount", event["sellTokenAmount"] / 1e18)
+            print("Buy amount", event["buyTokenAmount"] / 1e18)
+            print(
+                "Effective price:", event["sellTokenAmount"] / event["buyTokenAmount"]
+            )
+            bal = Contract(swapper.tokenOut()).balanceOf(swapper) / 1e18
+            vault_bal = vault.balanceOf(swapper) / 1e18
+            print(f"Remaining yCRV balance {bal}")
+            print(f"Remaining st-yCRV balance {vault_bal}\n")
+        else:
+            assert "OTC" not in tx.events
+            print("⏭️ Skipped OTC for:", amounts[i] / 1e18, "st-yCRV donation")
 
 
 def test_swapper_settings(swapper_v4, management, user):

--- a/tests/test_swapper.py
+++ b/tests/test_swapper.py
@@ -18,7 +18,8 @@ def test_swapper(
     swapper = swapper_v4
     strategy = old_strategy
     old_swapper = Contract(strategy.swapper())
-    price = 1 / (swapper.priceOracle() / 1e18)  # yCRV price as crvUSD
+    price = (swapper.priceOracle() / 1e18)  # yCRV price as crvUSD
+    print("\n👀 Price:", price, "\n")
     assert price > 0.10 and price < 1.0
     tx = strategy.harvest({"from": gov})
     strategy.upgradeSwapper(swapper, {"from": gov})
@@ -33,6 +34,7 @@ def test_swapper(
     swapper.setVault(v, {"from": gov})
 
     amounts = [10e18, 1_000e18, 100_000e18, 0]
+    swapper.enableOtc(True, {"from": management})
 
     status = swapper.otcEnabled()
 
@@ -44,10 +46,6 @@ def test_swapper(
         chain.sleep(WEEK)
         chain.mine()
 
-        if i % 3 == 0:
-            swapper.enableOtc(not status, {"from": management})
-            assert swapper.otcEnabled() != status
-
         status = swapper.otcEnabled()
 
         tx = strategy.harvest({"from": gov})
@@ -57,6 +55,7 @@ def test_swapper(
             event = tx.events["OTC"]
             print("Sell amount", event["sellTokenAmount"] / 1e18)
             print("Buy amount", event["buyTokenAmount"] / 1e18)
+            print("Effective price:", event["sellTokenAmount"] / event["buyTokenAmount"])
             bal = Contract(swapper.tokenOut()).balanceOf(swapper) / 1e18
             print(f"Remaining OTC balance {bal}\n")
         else:

--- a/tests/test_swapper.py
+++ b/tests/test_swapper.py
@@ -13,7 +13,9 @@ def test_swapper(
     gov,
     old_strategy,
     management,
+    user,
     crvusd_dummy_vault,
+    fund_ycrv,
 ):
     swapper = swapper_v5
     strategy = old_strategy
@@ -24,7 +26,6 @@ def test_swapper(
     tx = strategy.harvest({"from": gov})
     strategy.upgradeSwapper(swapper, {"from": gov})
     assert swapper.management() == management
-    whale = accounts.at("0x2DbcBdB6ED8DF05dDc859bd9e06A53E93e1C9561", force=True)
     ycrv = Contract(vault.token())
     chain.sleep(3 * WEEK)
     chain.mine()
@@ -33,22 +34,22 @@ def test_swapper(
     swapper.setVault(crvusd_dummy_vault, {"from": gov})
     swapper.setVault(v, {"from": gov})
 
-    amounts = [10e18, 1_000e18, 100_000e18, 0]
+    amounts = [10 * 10**18, 1_000 * 10**18, 100_000 * 10**18, 0]
     swapper.enableOtc(True, {"from": management})
 
     # test our operator role
     with brownie.reverts("!operator"):
-        swapper.enableOtc(False, {"from": whale})
-    swapper.setOperator(whale, True, {"from": management})
-    swapper.enableOtc(False, {"from": whale})
+        swapper.enableOtc(False, {"from": user})
+    swapper.setOperator(user, True, {"from": management})
+    swapper.enableOtc(False, {"from": user})
     assert not swapper.otcEnabled()
-    swapper.enableOtc(True, {"from": whale})
+    swapper.enableOtc(True, {"from": user})
     assert swapper.otcEnabled()
 
     status = swapper.otcEnabled()
 
     for i in range(len(amounts)):
-        ycrv.transfer(swapper, amounts[i], {"from": whale})
+        fund_ycrv(swapper, amounts[i])
 
         deposit_rewards()
 
@@ -82,6 +83,9 @@ def test_swapper_withdraw(
     old_strategy,
     management,
     crvusd_dummy_vault,
+    token,
+    user,
+    fund_ycrv,
 ):
     swapper = swapper_v5
     strategy = old_strategy
@@ -92,10 +96,6 @@ def test_swapper_withdraw(
     tx = strategy.harvest({"from": gov})
     strategy.upgradeSwapper(swapper, {"from": gov})
     assert swapper.management() == management
-    whale = accounts.at(
-        "0xEfb8B98A4BBd793317a863f1Ec9B92641aB1CBbb", force=True
-    )  # st-ycrv whale
-    ycrv = Contract(vault.token())
     chain.sleep(3 * WEEK)
     chain.mine()
 
@@ -103,13 +103,21 @@ def test_swapper_withdraw(
     swapper.setVault(crvusd_dummy_vault, {"from": gov})
     swapper.setVault(v, {"from": gov})
 
-    amounts = [10e18, 1_000e18, 100_000e18, 0]
+    amounts = [10 * 10**18, 1_000 * 10**18, 100_000 * 10**18, 0]
     swapper.enableOtc(True, {"from": management})
+
+    shares_needed = sum(amounts)
+    assets_needed = (shares_needed * vault.pricePerShare()) // 10**18
+    assets_needed = (assets_needed * 101) // 100
+    fund_ycrv(user, assets_needed)
+    token.approve(vault, assets_needed, {"from": user})
+    vault.deposit(assets_needed, {"from": user})
+    assert vault.balanceOf(user) >= shares_needed
 
     status = swapper.otcEnabled()
 
     for i in range(len(amounts)):
-        vault.transfer(swapper, amounts[i], {"from": whale})
+        vault.transfer(swapper, amounts[i], {"from": user})
 
         deposit_rewards()
 
@@ -140,8 +148,8 @@ def test_swapper_withdraw(
             print("⏭️ Skipped OTC for:", amounts[i] / 1e18, "st-yCRV donation")
 
 
-def test_swapper_settings(swapper_v4, management, user):
-    swapper = swapper_v4
+def test_swapper_settings(swapper_v5, management, user):
+    swapper = swapper_v5
     swapper.setAllowedSwapper(user, True, {"from": management})
     assert swapper.allowedSwapper(user)
     swapper.setAllowedSwapper(user, False, {"from": management})

--- a/tests/test_trigger.py
+++ b/tests/test_trigger.py
@@ -1,43 +1,53 @@
-import brownie
-from brownie import Contract
-import pytest
-
-
 def test_operation(
     chain,
-    accounts,
     token,
     gov,
     vault,
-    ybs,
     reward_distributor,
     strategy,
     user,
-    utils,
-    amount,
-    RELATIVE_APPROX,
-    deposit_rewards,
+    fund_ycrv,
 ):
-    token.approve(vault.address, amount, {"from": user})
     WEEK = 60 * 60 * 24 * 7
     threshold = strategy.thresholdTimeUntilWeekEnd()
-    trigger = strategy.harvestTrigger(0)
-    if trigger:
-        strategy.harvest({"from": gov})
-
-    week_end = int(chain.time() / WEEK + 1) * WEEK
+    week_end = (chain.time() // WEEK + 1) * WEEK
     time_until_week_end = week_end - chain.time()
-    threshold_start = week_end - threshold
-    if time_until_week_end > threshold_start:
-        chain.sleep(time_until_week_end - threshold_start + 1)
+    if time_until_week_end <= threshold:
+        chain.sleep(time_until_week_end + 1)
         chain.mine()
 
-    strategy.setCreditThreshold(100e18, {"from": gov})
+    credit_threshold = 25_000 * 10 ** token.decimals()
+    params = vault.strategies(strategy)
+    migration_profit = max(
+        strategy.estimatedTotalAssets() - params["totalDebt"],
+        0,
+    )
+    assert migration_profit < credit_threshold
+
+    strategy.setCreditThreshold(credit_threshold, {"from": gov})
+    assert not strategy.harvestTrigger(0)
 
     amount = strategy.creditThreshold() + 1
+    below_threshold_amount = 10 ** token.decimals()
+    fund_ycrv(user, amount + below_threshold_amount)
+    assert token.balanceOf(user) >= amount + below_threshold_amount
+    token.approve(vault.address, 2**256 - 1, {"from": user})
+
     vault.deposit(amount, {"from": user})
     assert strategy.harvestTrigger(0)
     strategy.harvest({"from": gov})
-    assert not strategy.harvestTrigger(0)
-    vault.deposit(1e18, {"from": user})
+    params = vault.strategies(strategy)
+    trigger_state = {
+        "force": strategy.forceHarvestTriggerOnce(),
+        "report_age": chain.time() - params["lastReport"],
+        "min_report_delay": strategy.minReportDelay(),
+        "claimable": reward_distributor.getClaimable(strategy),
+        "credit_available": vault.creditAvailable({"from": strategy}),
+        "credit_threshold": strategy.creditThreshold(),
+        "time_until_week_end": (chain.time() // WEEK + 1) * WEEK - chain.time(),
+        "week_end_threshold": threshold,
+    }
+    print("Trigger state after harvest:", trigger_state)
+    assert not strategy.harvestTrigger(0), trigger_state
+    vault.deposit(below_threshold_amount, {"from": user})
     assert not strategy.harvestTrigger(0)


### PR DESCRIPTION
build on top of latest swapper V4 (with oracle fix) and keep OTC tokens as st-yCRV in swapper so they continue to earn yield prior to selling. Diff between versions: https://www.diffchecker.com/UZBtRiXf/